### PR TITLE
Rename remote cache server property name

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ export GRADLE_CACHE_REMOTE_URL=https://ge.mycompany.com/
 ```
 
 ```
-./gradlew myBuildTask -Dgradle.cache.remote.url=https://ge.mycompany.com/
+./gradlew myBuildTask -Dgradle.cache.remote.server=https://ge.mycompany.com/
 ```
 
 To enable build scan publishing, you need to correctly authenticate as documented [here](https://docs.gradle.com/enterprise/gradle-plugin/#authenticating_with_gradle_enterprise).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 rootProject.group = "com.github.gradle"
 rootProject.group = "io.github.gradle"
-rootProject.version = "0.8.0"
+rootProject.version = "0.9.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPlugin.java
+++ b/src/main/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPlugin.java
@@ -122,8 +122,8 @@ public abstract class GradleEnterpriseConventionsPlugin implements Plugin<Settin
         private static final String US_CACHE_NODE = "https://us-build-cache.gradle.org";
         private static final String AU_CACHE_NODE = "https://au-build-cache.gradle.org";
 
-        private static final String GRADLE_CACHE_REMOTE_URL_PROPERTY_NAME = "gradle.cache.remote.url";
-        private static final String GRADLE_CACHE_REMOTE_URL_ENV_NAME = "GRADLE_CACHE_REMOTE_URL";
+        private static final String GRADLE_CACHE_REMOTE_SERVER_PROPERTY_NAME = "gradle.cache.remote.server";
+        private static final String GRADLE_CACHE_REMOTE_SERVER_ENV_NAME = "GRADLE_CACHE_REMOTE_SERVER";
         private static final String DEVELOCITY_ACCESS_KEY = "DEVELOCITY_ACCESS_KEY";
         private static final String GRADLE_ENTERPRISE_ACCESS_KEY = "GRADLE_ENTERPRISE_ACCESS_KEY";
         private static final String GRADLE_CACHE_REMOTE_PUSH_PROPERTY_NAME = "gradle.cache.remote.push";
@@ -155,8 +155,8 @@ public abstract class GradleEnterpriseConventionsPlugin implements Plugin<Settin
         }
 
         private String determineRemoteCacheUrl() {
-            return conventions.environmentVariableProvider(GRADLE_CACHE_REMOTE_URL_ENV_NAME)
-                .orElse(conventions.systemPropertyProvider(GRADLE_CACHE_REMOTE_URL_PROPERTY_NAME))
+            return conventions.environmentVariableProvider(GRADLE_CACHE_REMOTE_SERVER_ENV_NAME)
+                .orElse(conventions.systemPropertyProvider(GRADLE_CACHE_REMOTE_SERVER_PROPERTY_NAME))
                 .orElse(conventions.systemPropertyProvider(GRADLE_CACHE_NODE_PROPERTY_NAME)
                     .map(cacheNode -> {
                         switch (cacheNode) {


### PR DESCRIPTION
In https://github.com/gradle/gradle-org-conventions-plugin/pull/22 we have migrated build cache node authentication to access key.

However, the new remote cache server value format is different from the old value, so simply changing the value would break old builds.

To fix this incompatibility, let's rename the property name:

- `gradle.cache.remote.url` -> `gradle.cache.remote.server`
- `GRADLE_CACHE_REMOTE_URL` -> `GRADLE_CACHE_REMOTE_SERVER`

In this way we can keep both the old and new value for the builds.