### PR TITLE
Add custom publish strategy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 rootProject.group = "io.github.gradle"
-rootProject.version = "0.10.0"
+rootProject.version = "0.10.1"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/java/com/gradle/enterprise/conventions/PublishingConfigurationAction.java
+++ b/src/main/java/com/gradle/enterprise/conventions/PublishingConfigurationAction.java
@@ -5,7 +5,7 @@ import org.gradle.api.Action;
 
 public abstract class PublishingConfigurationAction implements Action<BuildScanPublishingConfiguration> {
 
-    public static final PublishingConfigurationAction PUBLISH_IF_AUTHENTICATED = new PublishingConfigurationAction("publishWhenAuthenticated") {
+    public static final PublishingConfigurationAction PUBLISH_IF_AUTHENTICATED = new PublishingConfigurationAction("publishIfAuthenticated") {
         @Override
         public void execute(BuildScanPublishingConfiguration publishing) {
             publishing.onlyIf(BuildScanPublishingConfiguration.PublishingContext::isAuthenticated);
@@ -22,6 +22,15 @@ public abstract class PublishingConfigurationAction implements Action<BuildScanP
         @Override
         public void execute(BuildScanPublishingConfiguration publishing) {
             publishing.onlyIf(__ -> true);
+        }
+    };
+
+    /**
+     * Don't apply any publishing strategy, the user will configure in their own init script.
+     */
+    public static final PublishingConfigurationAction CUSTOM = new PublishingConfigurationAction("custom") {
+        @Override
+        public void execute(BuildScanPublishingConfiguration publishing) {
         }
     };
     public final String name;

--- a/src/test/java/com/gradle/enterprise/conventions/DevelocityConventionsPluginIntegrationTest.java
+++ b/src/test/java/com/gradle/enterprise/conventions/DevelocityConventionsPluginIntegrationTest.java
@@ -44,23 +44,39 @@ public class DevelocityConventionsPluginIntegrationTest extends AbstractDeveloci
         succeeds("help");
 
         assertNull(getConfiguredRemoteCache().getUrl());
-        assertTrue(getConfiguredBuildScan().isPublishAlways());
         assertEquals(PUBLIC_GRADLE_ENTERPRISE_SERVER, getConfiguredDevelocity().getServerValue());
         assertTrue(getConfiguredBuildScan().isCaptureFileFingerprints());
         assertTrue(getConfiguredBuildScan().isPublishIfAuthenticated());
         assertTrue(getConfiguredBuildScan().isUploadInBackground());
     }
 
-    @Test
-    public void configurePublishOnFailure() {
-        succeeds("help", "-DpublishStrategy=publishOnFailure", "-Dgradle.enterprise.url=https://ge.gradle.org");
+    @ParameterizedTest
+    @ValueSource(strings = {"publishOnFailure", "publishAlways", "custom"})
+    public void configurePublishStrategy(String strategy) {
+        succeeds("help", "-DpublishStrategy=" + strategy, "-Dgradle.enterprise.url=https://ge.gradle.org");
 
         assertNull(getConfiguredRemoteCache().getUrl());
-        assertTrue(getConfiguredBuildScan().isPublishOnFailure());
         assertEquals(PUBLIC_GRADLE_ENTERPRISE_SERVER, getConfiguredDevelocity().getServerValue());
-        assertTrue(getConfiguredBuildScan().isCaptureFileFingerprints());
+        switch (strategy) {
+            case "publishOnFailure":
+                assertTrue(getConfiguredBuildScan().isPublishOnFailure());
+                break;
+            case "publishAlways":
+                assertTrue(getConfiguredBuildScan().isPublishAlways());
+                break;
+            case "custom":
+                assertTrue(getConfiguredBuildScan().isCustomPublish());
+                break;
+        }
+    }
+
+    @Test
+    public void defaultPublishStrategyIsPublishIfAuthenticated() {
+        succeeds("help", "-Dgradle.enterprise.url=https://ge.gradle.org");
+
+        assertNull(getConfiguredRemoteCache().getUrl());
         assertTrue(getConfiguredBuildScan().isPublishIfAuthenticated());
-        assertTrue(getConfiguredBuildScan().isUploadInBackground());
+        assertEquals(PUBLIC_GRADLE_ENTERPRISE_SERVER, getConfiguredDevelocity().getServerValue());
     }
 
     @Test

--- a/src/test/java/com/gradle/enterprise/fixtures/BuildScanConfigurationForTest.java
+++ b/src/test/java/com/gradle/enterprise/fixtures/BuildScanConfigurationForTest.java
@@ -16,6 +16,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.gradle.enterprise.conventions.PublishingConfigurationAction.CUSTOM;
+import static com.gradle.enterprise.conventions.PublishingConfigurationAction.PUBLISH_ALWAYS;
+import static com.gradle.enterprise.conventions.PublishingConfigurationAction.PUBLISH_IF_AUTHENTICATED;
+import static com.gradle.enterprise.conventions.PublishingConfigurationAction.PUBLISH_ON_FAILURE;
+
 public class BuildScanConfigurationForTest implements BuildScanConfigurationInternal {
     public BuildScanConfigurationForTest() {
         this(null);
@@ -238,7 +243,7 @@ public class BuildScanConfigurationForTest implements BuildScanConfigurationInte
 
     @JsonIgnore
     public boolean isPublishOnFailure() {
-        return publishConfigurationActions.contains(PublishingConfigurationAction.PUBLISH_ON_FAILURE.name);
+        return publishConfigurationActions.contains(PUBLISH_ON_FAILURE.name);
     }
 
     @Override
@@ -311,12 +316,18 @@ public class BuildScanConfigurationForTest implements BuildScanConfigurationInte
 
     @JsonIgnore
     public boolean isPublishIfAuthenticated() {
-        return publishConfigurationActions.contains(PublishingConfigurationAction.PUBLISH_IF_AUTHENTICATED.name);
+        return publishConfigurationActions.contains(PUBLISH_IF_AUTHENTICATED.name);
     }
 
     @JsonIgnore
+    public boolean isCustomPublish() {
+        return publishConfigurationActions.contains(CUSTOM.name);
+    }
+
+
+    @JsonIgnore
     public boolean isPublishAlways() {
-        return publishConfigurationActions.contains(PublishingConfigurationAction.PUBLISH_ALWAYS.name);
+        return publishConfigurationActions.contains(PUBLISH_ALWAYS.name);
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-org-conventions-plugin/issues/28

This PR adds a `-DpublishStrategy=custom` which does no-op to allow developers apply their own publishing logic code.