### PR TITLE
Add support for `DEVELOCITY_SERVER_URL` env and remove old cache properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,11 @@ When applied as a settings plugin alongside the [Develocity Plugin](https://plug
 
 - If the build cache is enabled (via `--build-cache` or `org.gradle.caching=true`, see [the doc](https://guides.gradle.org/using-build-cache/)):
   - Enable the local cache.
-  - Enable [ge.gradle.org](https://ge.gradle.org) as remote cache if credentials are provided, enjoy faster build! (using your preferred [location](https://ge.gradle.org/settings/location)) 
-  - Enable [ge.gradle.org](https://ge.gradle.org) as remote cache and anonymous read access, enjoy faster build!
-    - There are four build cache node available on the earth: `Develocity` (the default; Germany) /`eu` (Finland) /`us` (N.California) /`au` (Sydney), you can use `-DcacheNode=eu`/ `-DcacheNode=us`/`-DcacheNode=au` to use other ones.
+  - Enable [ge.gradle.org](https://ge.gradle.org) as remote cache with anonymous read access, enjoy faster build!
+  - Enable edge discovery by default so the nearest edge node is selected based on your preferred [location](https://ge.gradle.org/settings/location).
   - Enable pushing to remote cache on CI if required credentials are provided.
-- By default, build scans are published to `ge.gradle.org`. If you would like to publish to your own Develocity server, add `-Ddevelocity.server.url=https://ge.mycompany.com/`.
-  If you would like to publish to public build scan server (`scan.gradle.com`), add `-DagreePublicBuildScanTermOfService=yes` to your build.
+- By default, build scans are published to `ge.gradle.org`. If you would like to publish to your own Develocity server, set `-Ddevelocity.server.url=https://ge.example.org/` or the `DEVELOCITY_SERVER_URL` environment variable. The URL can point directly at an edge node (for example `https://edge.example.org`) to use a specific build cache location when edge discovery is disabled.
+  If you would like to publish to public build scan server (`scans.gradle.com`), add `-DagreePublicBuildScanTermOfService=yes` to your build.
   - For CI build (`CI` environment variable exists):
     - Add `CI` build scan tag.
     - Add build scan link and build scan custom value `gitCommitId` to the build (by auto-detecting environment variables):
@@ -58,22 +57,31 @@ plugins {
 ## Credentials
 
 To enable build scan publishing, authenticate with [Develocity](https://docs.gradle.com/develocity/gradle-plugin/current/#authenticating).
-Then add a `develocity.server.url` system property to your build if you publish to a different server than the default one.
+Then set the Develocity server URL via the `develocity.server.url` system property or the `DEVELOCITY_SERVER_URL` environment variable if you publish to a different server than the default one.
+
+Edge discovery is enabled by default for the remote build cache. To disable it, set the `develocity.edge.discovery` system property or the `DEVELOCITY_EDGE_DISCOVERY` environment variable to `false`. The system property takes precedence over the environment variable.
+
+The legacy `-DcacheNode` system property is no longer supported. Set your preferred location at [ge.gradle.org/settings/location](https://ge.gradle.org/settings/location) instead.
 
 ```
-./gradlew myBuildTask -Ddevelocity.server.url=https://ge.mycompany.com/
+./gradlew myBuildTask -Ddevelocity.server.url=https://ge.example.org/
+```
+
+```
+export DEVELOCITY_SERVER_URL=https://edge.example.org
+./gradlew myBuildTask
+```
+
+```
+./gradlew myBuildTask --build-cache -Ddevelocity.edge.discovery=false
+```
+
+```
+export DEVELOCITY_EDGE_DISCOVERY=false
+./gradlew myBuildTask --build-cache
 ```
 
 To enable build cache pushing, the access key associated with the build needs to have build cache write permission.
-
-```
-export GRADLE_CACHE_REMOTE_URL=https://ge.mycompany.com/
-./gradlew myBuildTask 
-```
-
-```
-./gradlew myBuildTask -Dgradle.cache.remote.server=https://ge.mycompany.com/
-```
 
 To enable build scan publishing, you need to correctly authenticate as documented [here](https://docs.gradle.com/develocity/gradle-plugin/current/#authenticating).
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 rootProject.group = "io.github.gradle"
-rootProject.version = "0.14.1"
+rootProject.version = "0.15.0"
 
 java {
     toolchain {

--- a/src/main/java/io/github/gradle/conventions/DevelocityConventionsPlugin.java
+++ b/src/main/java/io/github/gradle/conventions/DevelocityConventionsPlugin.java
@@ -120,10 +120,6 @@ public abstract class DevelocityConventionsPlugin implements Plugin<Settings> {
     }
 
     private static class BuildCacheConfigureAction implements Action<BuildCacheConfiguration> {
-        private static final String EU_CACHE_NODE = "https://eun-edge.gradle.org";
-        private static final String US_CACHE_NODE = "https://usw-edge.gradle.org";
-        private static final String AU_CACHE_NODE = "https://au-edge.gradle.org";
-
         private static final String DEVELOCITY_ACCESS_KEY = "DEVELOCITY_ACCESS_KEY";
         private static final String GRADLE_CACHE_REMOTE_PUSH_PROPERTY_NAME = "gradle.cache.remote.push";
         private final DevelocityConventions conventions;
@@ -136,33 +132,17 @@ public abstract class DevelocityConventionsPlugin implements Plugin<Settings> {
 
         @Override
         public void execute(BuildCacheConfiguration buildCache) {
-            String remoteCacheUrl = determineRemoteCacheUrl();
             boolean remotePush = Boolean.parseBoolean(conventions.getSystemProperty(GRADLE_CACHE_REMOTE_PUSH_PROPERTY_NAME, "false"));
             String develocityAccessKey = conventions.getEnvVariableThenSystemProperty(DEVELOCITY_ACCESS_KEY, DEVELOCITY_ACCESS_KEY, "");
             boolean disableLocalCache = Boolean.parseBoolean(conventions.getSystemProperty("disableLocalCache", "false"));
             buildCache.remote(dv.getBuildCache(), remoteBuildCache -> {
                 remoteBuildCache.setEnabled(true);
-                remoteBuildCache.setServer(remoteCacheUrl);
+                remoteBuildCache.setServer(conventions.getDevelocityServerUrl());
                 boolean accessKeySet = notNullOrEmpty(develocityAccessKey);
                 boolean push = (conventions.isCiServer() || remotePush) && accessKeySet;
                 remoteBuildCache.setPush(push);
             });
             buildCache.local(localBuildCache -> localBuildCache.setEnabled(!disableLocalCache));
-        }
-
-        private String determineRemoteCacheUrl() {
-            return conventions.getRemoteCacheUrl()
-                .getOrElse(getRemoteCacheUrlFromNodeName());
-        }
-
-        private String getRemoteCacheUrlFromNodeName() {
-            return conventions.getRemoteCacheNodeName()
-                .map(cacheNode -> switch (cacheNode) {
-                    case "eu" -> EU_CACHE_NODE;
-                    case "us" -> US_CACHE_NODE;
-                    case "au" -> AU_CACHE_NODE;
-                    default -> throw new IllegalArgumentException("Unrecognized cacheNode: " + cacheNode);
-                }).getOrNull();
         }
 
         private boolean notNullOrEmpty(String value) {

--- a/src/main/java/io/github/gradle/conventions/customvalueprovider/DevelocityConventions.java
+++ b/src/main/java/io/github/gradle/conventions/customvalueprovider/DevelocityConventions.java
@@ -34,12 +34,11 @@ public class DevelocityConventions {
     private static final String DEFAULT_DEVELOCITY_SERVER = "https://ge.gradle.org";
     private static final String AGREE_PUBLIC_BUILD_SCAN_TERM_OF_SERVICE = "agreePublicBuildScanTermOfService";
 
-    private static final String DEVELOCITY_SERVER_URL = "develocity.server.url";
-    private static final String DEVELOCITY_EDGE_DISCOVERY = "develocity.edge.discovery";
+    private static final String DEVELOCITY_SERVER_URL_PROPERTY_NAME = "develocity.server.url";
+    private static final String DEVELOCITY_SERVER_URL_ENV_NAME = "DEVELOCITY_SERVER_URL";
+    private static final String DEVELOCITY_EDGE_DISCOVERY_PROPERTY_NAME = "develocity.edge.discovery";
+    private static final String DEVELOCITY_EDGE_DISCOVERY_ENV_NAME = "DEVELOCITY_EDGE_DISCOVERY";
     private static final String CI_ENV_NAME = "CI";
-
-    private static final String GRADLE_CACHE_REMOTE_SERVER_ENV_NAME = "GRADLE_CACHE_REMOTE_SERVER";
-    private static final String GRADLE_CACHE_REMOTE_SERVER_PROPERTY_NAME = "gradle.cache.remote.server";
     private static final String GRADLE_CACHE_NODE_PROPERTY_NAME = "cacheNode";
 
     private static final Pattern HTTPS_URL_PATTERN = Pattern.compile("https://github\\.com/([\\w-]+)/([\\w-]+)\\.git");
@@ -56,27 +55,22 @@ public class DevelocityConventions {
         this.edgeDiscovery = determineEdgeDiscovery();
         this.develocityServerUrl = determineDevelocityServerUrl();
         this.isCiServer = !getEnvVariable(CI_ENV_NAME, "").isEmpty();
+        warnIfUnsupportedCacheNodePropertyIsSet();
     }
 
     private boolean determineEdgeDiscovery() {
-        return Boolean.parseBoolean(getSystemProperty(DEVELOCITY_EDGE_DISCOVERY, "true"));
+        return Boolean.parseBoolean(getSystemPropertyThenEnvVariable(DEVELOCITY_EDGE_DISCOVERY_PROPERTY_NAME, DEVELOCITY_EDGE_DISCOVERY_ENV_NAME, "true"));
     }
 
-    public Provider<String> getRemoteCacheUrl() {
-        return environmentVariableProvider(GRADLE_CACHE_REMOTE_SERVER_ENV_NAME)
-            .orElse(systemPropertyProvider(GRADLE_CACHE_REMOTE_SERVER_PROPERTY_NAME));
-    }
-
-    public Provider<String> getRemoteCacheNodeName() {
-        return systemPropertyProvider(GRADLE_CACHE_NODE_PROPERTY_NAME);
-    }
-
-    public boolean isRemoteCacheSpecified() {
-        return getRemoteCacheUrl().orElse(getRemoteCacheNodeName()).isPresent();
+    private void warnIfUnsupportedCacheNodePropertyIsSet() {
+        String cacheNode = getSystemProperty(GRADLE_CACHE_NODE_PROPERTY_NAME);
+        if (cacheNode != null) {
+            LOGGER.warn("-DcacheNode={} is no longger supported. Please set prefered location in {}/settings/location", cacheNode, DEFAULT_DEVELOCITY_SERVER);
+        }
     }
 
     private String determineDevelocityServerUrl() {
-        String dvServerUrl = System.getProperty(DEVELOCITY_SERVER_URL);
+        String dvServerUrl = getSystemPropertyThenEnvVariable(DEVELOCITY_SERVER_URL_PROPERTY_NAME, DEVELOCITY_SERVER_URL_ENV_NAME);
         if (dvServerUrl != null) {
             return dvServerUrl;
         }
@@ -117,6 +111,26 @@ public class DevelocityConventions {
     public String getEnvVariableThenSystemProperty(String envName, String systemPropertyName, String defaultValue) {
         String value = getEnv(envName);
         return value != null ? value : getSystemProperty(systemPropertyName, defaultValue);
+    }
+
+    public String getSystemPropertyThenEnvVariable(String systemPropertyName, String envName, String defaultValue) {
+        String value = getSystemPropertyThenEnvVariable(systemPropertyName, envName);
+        return value != null ? value : defaultValue;
+    }
+
+    @Nullable
+    public String getSystemPropertyThenEnvVariable(String systemPropertyName, String envName) {
+        String value = getSystemProperty(systemPropertyName);
+        if (value != null && !value.isEmpty()) {
+            return value;
+        }
+
+        value = getEnv(envName);
+        if (value != null && !value.isEmpty()) {
+            return value;
+        }
+
+        return null;
     }
 
     public String getSystemProperty(String name, String defaultValue) {

--- a/src/test/java/io/github/gradle/conventions/DevelocityConventionsPluginIntegrationTest.java
+++ b/src/test/java/io/github/gradle/conventions/DevelocityConventionsPluginIntegrationTest.java
@@ -19,25 +19,68 @@ class DevelocityConventionsPluginIntegrationTest extends AbstractDevelocityPlugi
     private static final String PUBLIC_DEVELOCITY_SERVER = "https://ge.gradle.org";
 
     @Test
-    void configureBuildCacheOnlyWhenBuildCacheEnabled() {
+    void configureBuildCacheOnlyWhenBuildCacheEnabled() throws URISyntaxException {
         succeeds("help", "--build-cache");
 
         assertTrue(getConfiguredDevelocity().getEdgeDiscoveryValue());
         assertEquals(PUBLIC_DEVELOCITY_SERVER, getConfiguredDevelocity().getServerValue());
-        assertNull(getConfiguredRemoteCache().getUrl());
+        assertEquals(new URI(PUBLIC_DEVELOCITY_SERVER), getConfiguredRemoteCache().getUrl());
         assertFalse(getConfiguredRemoteCache().isPush());
         assertTrue(getConfiguredLocalCache().isEnabled());
     }
 
     @Test
-    void configureBuildCacheOnlyWhenBuildCacheEnabledAndCacheNodeIsSet() throws URISyntaxException {
-        succeeds("help", "--build-cache", "-DcacheNode=eu");
+    void configureBuildCacheWithEdgeNodeUrl() throws URISyntaxException {
+        succeeds("help", "--build-cache", "-Ddevelocity.server.url=" + EU_CACHE_NODE);
 
         assertTrue(getConfiguredDevelocity().getEdgeDiscoveryValue());
-        assertEquals(PUBLIC_DEVELOCITY_SERVER, getConfiguredDevelocity().getServerValue());
+        assertEquals(EU_CACHE_NODE, getConfiguredDevelocity().getServerValue());
         assertEquals(new URI(EU_CACHE_NODE), getConfiguredRemoteCache().getUrl());
         assertFalse(getConfiguredRemoteCache().isPush());
         assertTrue(getConfiguredLocalCache().isEnabled());
+    }
+
+    @Test
+    void configureEdgeDiscoveryFromEnvironmentVariable() {
+        withEnvironmentVariable("DEVELOCITY_EDGE_DISCOVERY", "false");
+
+        succeeds("help", "--build-cache");
+
+        assertFalse(getConfiguredDevelocity().getEdgeDiscoveryValue());
+    }
+
+    @Test
+    void systemPropertyTakesPrecedenceOverEdgeDiscoveryEnvironmentVariable() {
+        withEnvironmentVariable("DEVELOCITY_EDGE_DISCOVERY", "false");
+
+        succeeds("help", "--build-cache", "-Ddevelocity.edge.discovery=true");
+
+        assertTrue(getConfiguredDevelocity().getEdgeDiscoveryValue());
+    }
+
+    @Test
+    void warnWhenUnsupportedCacheNodeSystemPropertyIsSet() {
+        String output = succeeds("help", "-DcacheNode=eu").getOutput();
+
+        assertTrue(output.contains("-DcacheNode=eu is no longger supported. Please set prefered location in https://ge.gradle.org/settings/location"));
+    }
+
+    @Test
+    void configureDevelocityServerUrlFromEnvironmentVariable() {
+        withEnvironmentVariable("DEVELOCITY_SERVER_URL", "https://ge.mycompany.com");
+
+        succeeds("help");
+
+        assertEquals("https://ge.mycompany.com", getConfiguredDevelocity().getServerValue());
+    }
+
+    @Test
+    void systemPropertyTakesPrecedenceOverDevelocityServerUrlEnvironmentVariable() {
+        withEnvironmentVariable("DEVELOCITY_SERVER_URL", "https://ge.mycompany.com");
+
+        succeeds("help", "-Ddevelocity.server.url=https://ge.example.com");
+
+        assertEquals("https://ge.example.com", getConfiguredDevelocity().getServerValue());
     }
 
     @Test
@@ -128,7 +171,7 @@ class DevelocityConventionsPluginIntegrationTest extends AbstractDevelocityPlugi
     @ParameterizedTest
     @ValueSource(strings = {"develocity.server.url"})
     void configureBuildScanViaSystemProperties(String paramName) {
-        succeeds("help", "-DcacheNode=us", "-D" + paramName + "=https://ge.mycompany.com");
+        succeeds("help", "-D" + paramName + "=https://ge.mycompany.com");
 
         assertEquals("https://ge.mycompany.com", getConfiguredDevelocity().getServerValue());
     }

--- a/src/test/java/io/github/gradle/fixtures/AbstractDevelocityPluginIntegrationTest.java
+++ b/src/test/java/io/github/gradle/fixtures/AbstractDevelocityPluginIntegrationTest.java
@@ -2,6 +2,7 @@ package io.github.gradle.fixtures;
 
 import org.gradle.caching.http.HttpBuildCache;
 import org.gradle.caching.local.DirectoryBuildCache;
+import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -132,7 +133,7 @@ public abstract class AbstractDevelocityPluginIntegrationTest {
         return new BufferedReader(new InputStreamReader(is)).lines().collect(Collectors.joining("\n"));
     }
 
-    protected void succeeds(String... args) {
+    protected BuildResult succeeds(String... args) {
         var gradleHomeDir = projectDir.resolve("gradleHome");
         Assertions.assertDoesNotThrow(() -> Files.createDirectories(gradleHomeDir));
 
@@ -144,7 +145,7 @@ public abstract class AbstractDevelocityPluginIntegrationTest {
         tasksAndArguments.add("--info");
         writeSystemProperties(Stream.of(args).filter(s -> s.startsWith("-D")).toList());
 
-        GradleRunner.create()
+        return GradleRunner.create()
             .withProjectDir(projectDir.toFile())
             .withEnvironment(buildEnvs())
             .withPluginClasspath(Stream.of(System.getProperty("java.class.path").split(File.pathSeparator)).map(File::new).toList())


### PR DESCRIPTION
Previously, we configured Develocity and the build cache separately:

- `-Ddevelocity.server.url=https://ge.mycompany.com`/ for the Develocity server
- `-DcacheNode=X` to select a cache node
- `GRADLE_CACHE_REMOTE_SERVER` / `-Dgradle.cache.remote.server` to configure the remote build cache

With edge nodes, a single edge URL can be used directly as the Develocity server URL, so those cache-specific properties are no longer needed.

This PR:

1. Removes the legacy cache properties (`cacheNode`, `GRADLE_CACHE_REMOTE_SERVER`, and `gradle.cache.remote.server`)
2. Adds support for the `DEVELOCITY_SERVER_URL` environment variable to configure the Develocity server URL

### The old behavior

On developer's machine, user set `-DcacheNode=X` in `gradle.properties`. Then the plugin set server url to default `get.gradle.org`. The edge discovery is default `true`, so if user also sets the perfered location, the actual edge used is "undefined behavior".

On CI, we use two users: `teamcity` and `teamcityus`, which have prefered location accordingly. Then the plugin set server url to default `get.gradle.org`. The edge node used is determined by which user's access key is used.

### Proposed new behavior

Keep the default server url to be `ge.gradle.org`. 

Drop support `cacheNode`, but print a warming like:

```
-DcacheNode=X is no longger supported. Please set prefered location in https://ge.gradle.org/settings/location
```

On Ci, we inject `DEVELOCITY_SERVER_URL=<TheEdgeServerUrlInThatRegion>` and `DEVELOCITY_EDGE_DISCOVERY=false`.