### PR TITLE
Update signing configuration for PGP subkey

### DIFF
--- a/.teamcity/Project.kt
+++ b/.teamcity/Project.kt
@@ -110,6 +110,7 @@ object ReleasePlugin : BuildType({
     params {
         param("env.GRADLE_PUBLISH_KEY", "%plugin.portal.publish.key%")
         param("env.GRADLE_PUBLISH_SECRET", "%plugin.portal.publish.secret%")
+        param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")
         param("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
         param("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,8 @@ gradlePlugin {
 
 signing {
     useInMemoryPgpKeys(
+        // Key ID required when signing with a subkey
+        project.providers.environmentVariable("PGP_SIGNING_KEY_ID").orNull,
         project.providers.environmentVariable("PGP_SIGNING_KEY").orNull,
         project.providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE").orNull
     )


### PR DESCRIPTION
After the move to a signing subkey following the August 14 security incident, `useInMemoryPgpKeys` needs the key ID as its first argument — without it the signing plugin falls back to the primary key.

This adds the key ID to the `signing {}` block and makes the publishing build configuration pass it as `env.PGP_SIGNING_KEY_ID`, matching what was already done in gradle/gradle#38874, gradle/gradle-promote#382 and gradle/gradle-pom-properties#20.

The `pgpSigningKeyId` TeamCity parameter is already defined on the parent project, so no new secret is needed.

Docs: https://docs.gradle.org/current/userguide/signing_plugin.html#sec:subkeys
Part of gradle/gradle-private#5321